### PR TITLE
Add filament-check-pro skill

### DIFF
--- a/skills/filament-check-pro/SKILL.md
+++ b/skills/filament-check-pro/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: filament-check-pro
+description: Executa filacheck, interpreta resultados e corrige problemas proativamente
+license: MIT
+compatibility: Requer Filament 4+ e Laravel 11+
+metadata:
+  author: aronpc
+  version: 1.0.0
+  category: development
+  package: povilas/filament-check-pro
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Bash
+---
+
+# Filament Check Pro
+
+Esta skill **executa**, **interpreta** e **corrige proativamente** os problemas encontrados pelo [Filament Check Pro](https://github.com/povilaskorop/filament-check-pro).
+
+## Comportamento esperado
+
+Quando esta skill é invocada:
+
+1. **Rodar** `php artisan filacheck --detailed`
+2. **Entender** a saída e identificar problemas
+3. **Corrigir** proativamente os arquivos afetados
+
+## Fluxo de execução
+
+```bash
+# 1. Executar análise
+php artisan filacheck --detailed
+
+# 2. Tentar auto-fix primeiro
+php artisan filacheck --fix --backup
+
+# 3. Para problemas manuais, editar os arquivos diretamente
+```
+
+## Interpretação da saída
+
+```
+Scanning: /path/to/app/Filament
+
+Deprecated Code
+  ✓ deprecated-reactive           # OK, sem problemas
+  ✗ deprecated-placeholder (5)    # 5 problemas para corrigir
+    /path/to/file.php
+      Line 42: The `Placeholder` component is deprecated
+        → Use `TextEntry::make()->state()` instead
+
+Performance
+  ✗ table-defer-loading (20)     # 20 tabelas sem deferLoading()
+
+Found 36 warning(s).
+```
+
+- **✓** = Sem problemas
+- **✗ (N)** = N problemas encontrados
+- **→** = Sugestão de correção (aplicar proativamente)
+
+## Priorização de correções
+
+1. **Alta prioridade** - Deprecated code (quebra em versões futuras)
+2. **Média prioridade** - Performance (N+1 queries, loading)
+3. **Baixa prioridade** - Best practices
+
+## Padrões de correção mais comuns
+
+### Placeholder → TextEntry
+```php
+// Substituir
+Placeholder::make('xxx')->content('yyy')
+// Por
+TextEntry::make('xxx')->state('yyy')
+```
+
+### reactive() → live()
+```php
+// Substituir
+->reactive()
+// Por
+->live()
+```
+
+### Adicionar deferLoading()
+```php
+public function table(Table $table): Table
+{
+    return $table
+        ->columns([...])
+        ->deferLoading(); // ADICIONAR ISTO
+}
+```
+
+### Adicionar eager loading
+```php
+public function table(Table $table): Table
+{
+    return $table
+        ->modifyQueryUsing(fn (Builder $query) => $query->with(['user', 'category']))
+        ->columns([...]);
+}
+```
+
+## Arquivos comuns com problemas
+
+- `RelationManagers/*.php` → `deferLoading()`, eager loading
+- `Resources/*/Schemas/*Form.php` → Components deprecated
+- `Widgets/*.php` → Performance de queries
+- `resources/views/filament/**/*.blade.php` → Custom theme
+
+## Referências
+
+- `references/rules-detailed.md` - Lista completa de regras com exemplos
+- [Repositório oficial](https://github.com/povilaskorop/filament-check-pro)

--- a/skills/filament-check-pro/references/rules-detailed.md
+++ b/skills/filament-check-pro/references/rules-detailed.md
@@ -1,0 +1,121 @@
+# Regras Detalhadas do Filament Check Pro
+
+## Todas as Regras Disponíveis
+
+### Deprecated Code
+
+| Regra | Descrição | Severidade |
+|-------|-----------|------------|
+| `deprecated-reactive` | Uso do método `reactive()` | Alta |
+| `deprecated-action-form` | Uso de `form()` em Actions | Alta |
+| `deprecated-filter-form` | Uso de Filter Form deprecated | Alta |
+| `deprecated-placeholder` | Componente `Placeholder` deprecated | Alta |
+| `deprecated-mutate-form-data-using` | Uso de `mutateFormDataUsing()` antigo | Média |
+| `deprecated-empty-label` | Uso de `label()` vazio | Baixa |
+| `deprecated-forms-set` | Uso de `Forms::set()` deprecated | Alta |
+| `deprecated-image-column-size` | Uso de `size()` em ImageColumn | Média |
+| `deprecated-notification-action-namespace` | Namespace de Actions em notifications | Baixa |
+
+### Performance
+
+| Regra | Descrição | Impacto |
+|-------|-----------|---------|
+| `too-many-columns` | Table com >15 colunas | UX |
+| `table-defer-loading` | Table sem `deferLoading()` | Alto |
+| `table-missing-eager-loading` | Table sem eager loading em relacionamentos | Crítico |
+| `large-option-list-searchable` | SelectList grande sem searchable | Médio |
+
+### Best Practices
+
+| Regra | Descrição | Benefício |
+|-------|-----------|-----------|
+| `string-icon-instead-of-enum` | Usar strings para icons | Compatibilidade |
+| `string-font-weight-instead-of-enum` | Usar strings para font-weight | Compatibilidade |
+| `unnecessary-unique-ignore-record` | `unique()` desnecessário em updates | Limpeza |
+| `custom-theme-needed` | Blade com Tailwind sem tema | UX |
+
+## Exemplos de Correção
+
+### 1. RelationManager com múltiplos problemas
+
+**Antes:**
+```php
+class PhotosRelationManager extends RelationManager
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('title'),
+                ImageColumn::make('url')->size(40),
+                TextColumn::make('user.name'), // N+1 query
+                Placeholder::make('count')
+                    ->content(fn () => $this->ownerRecord->photos->count()),
+            ]);
+    }
+}
+```
+
+**Depois:**
+```php
+class PhotosRelationManager extends RelationManager
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->modifyQueryUsing(fn (Builder $query) => $query->with('user'))
+            ->deferLoading()
+            ->columns([
+                TextColumn::make('title'),
+                ImageColumn::make('url')->size(40), // Removido se v4+
+                TextColumn::make('user.name'),
+                TextEntry::make('count')
+                    ->state(fn () => $this->ownerRecord->photos->count()),
+            ]);
+    }
+}
+```
+
+### 2. Form com components deprecated
+
+**Antes:**
+```php
+return $form
+    ->schema([
+        TextInput::make('email')
+            ->reactive()
+            ->afterStateUpdated(fn ($state, callable $set) => $set('username', Str::slug($state))),
+        Placeholder::make('preview')
+            ->content(fn (callable $get) => $get('email')),
+    ]);
+```
+
+**Depois:**
+```php
+return $form
+    ->schema([
+        TextInput::make('email')
+            ->live()
+            ->afterStateUpdated(fn ($state, callable $set) => $set('username', Str::slug($state))),
+        TextEntry::make('preview')
+            ->state(fn (callable $get) => $get('email')),
+    ]);
+```
+
+## Cheatsheet de Migração v3 → v4/v5
+
+| v3 | v4/v5 |
+|----|-------|
+| `->reactive()` | `->live()` |
+| `Placeholder::make()` | `TextEntry::make()->state()` |
+| `Forms\set()` | `Livewire\wire()->set()` |
+| `Icons::*` | `'heroicon-o-*'` |
+| `->size()` em ImageColumn | Remover ou usar CSS |
+| `->mutateFormDataUsing()` em Resource | Em Create/EditPage |
+
+## Links Úteis
+
+- [Upgrade Guide v4](https://filamentphp.com/docs/4.x/upgrade)
+- [Upgrade Guide v5](https://filamentphp.com/docs/5.x/upgrade)
+- [Performance Optimization](https://filamentphp.com/docs/3.x/tables/installation#defer-loading)
+- [Eager Loading](https://filamentphp.com/docs/3.x/queries/eloquent-relationships)


### PR DESCRIPTION
## Summary
- Add new `filament-check-pro` skill for interpreting and proactively fixing Filament static analysis issues
- Includes `SKILL.md` (118 lines) with execution workflow and common correction patterns
- Includes `rules-detailed.md` reference with comprehensive rule explanations and migration examples

## Features
- Executes `php artisan filacheck --detailed` automatically
- Interprets output and categorizes problems by priority
- Provides proactive fix guidance for deprecated code and performance issues
- Compatible with Filament 4+, Laravel 11+

## Test plan
- [x] Skill structure follows Agent Skills specification
- [x] SKILL.md under 500 lines limit
- [x] References directory with detailed rules
- [ ] Test in actual Laravel project with Filament

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentação**
  * Adicionada documentação completa da skill Filament Check Pro, incluindo especificação de comportamento, regras de análise categorizadas (código deprecado, performance, boas práticas), padrões de correção com exemplos antes/depois, e guia de migração entre versões com links úteis para upgrade e otimização.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->