### PR TITLE
add: laravel-enums skill with archtechx/enums guide

### DIFF
--- a/skills/laravel-enums/SKILL.md
+++ b/skills/laravel-enums/SKILL.md
@@ -1,0 +1,410 @@
+---
+name: laravel-enums
+description: Skill para trabalhar com enums PHP 8.1+ usando o pacote archtechx/enums. Fornece 7 traits que adicionam métodos helpers para: invocação, nomes, valores, opções, from/to, metadados e comparações.
+license: MIT
+compatibility: Requer PHP 8.1+, Composer. Pacote: archtechx/enums
+metadata:
+  author: aronpc
+  version: 1.0.0
+  category: development
+  package: archtechx/enums
+  github: https://github.com/archtechx/enums
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+---
+
+# Laravel Enums (archtechx/enums)
+
+Skill para trabalhar com enums PHP 8.1+ usando o pacote `archtechx/enums`.
+
+## Instalação
+
+```bash
+composer require archtechx/enums
+```
+
+## Quando usar esta skill
+
+Use esta skill quando:
+- Criar ou modificar enums PHP no projeto Laravel
+- Precisar de métodos helpers para enums (names, values, options, etc.)
+- Implementar comparações entre enums
+- Adicionar metadados aos cases do enum
+- Cast enums em modelos Eloquent
+- Validar inputs usando enums
+
+## Os 7 Traits Disponíveis
+
+### 1. InvokableCases - Invocação de Enums
+
+Permite obter o valor de um backed enum ou o nome de um pure enum através de "invocação".
+
+```php
+use ArchTech\Enums\InvokableCases;
+
+enum TaskStatus: int
+{
+    use InvokableCases;
+
+    case INCOMPLETE = 0;
+    case COMPLETED = 1;
+    case CANCELED = 2;
+}
+
+// Chamada estática - retorna o valor
+TaskStatus::INCOMPLETE();  // 0
+
+// Invocação de instância
+$status = TaskStatus::INCOMPLETE;
+$status();  // 0
+
+// Como chave de array (muito útil!)
+$config = [
+    TaskStatus::INCOMPLETE() => ['color' => 'gray'],
+    TaskStatus::COMPLETED() => ['color' => 'green'],
+];
+```
+
+### 2. Names - Lista de Nomes
+
+Retorna array com os nomes dos cases.
+
+```php
+use ArchTech\Enums\Names;
+
+enum TaskStatus: int
+{
+    use Names;
+
+    case INCOMPLETE = 0;
+    case COMPLETED = 1;
+}
+
+TaskStatus::names();
+// ['INCOMPLETE', 'COMPLETED']
+```
+
+### 3. Values - Lista de Valores
+
+Retorna array com os valores dos cases (ou nomes para pure enums).
+
+```php
+use ArchTech\Enums\Values;
+
+enum TaskStatus: int
+{
+    use Values;
+
+    case INCOMPLETE = 0;
+    case COMPLETED = 1;
+}
+
+TaskStatus::values();
+// [0, 1]
+```
+
+### 4. Options - Array Associativo
+
+Retorna array associativo `nome => valor`.
+
+```php
+use ArchTech\Enums\Options;
+
+enum TaskStatus: int
+{
+    use Options;
+
+    case INCOMPLETE = 0;
+    case COMPLETED = 1;
+}
+
+TaskStatus::options();
+// ['INCOMPLETE' => 0, 'COMPLETED' => 1]
+
+// stringOptions() - gera HTML <option>
+TaskStatus::stringOptions();
+// <option value="0">Incomplete</option>
+// <option value="1">Completed</option>
+```
+
+### 5. From - From/Name Resolution
+
+Adiciona `from()` e `tryFrom()` para pure enums, e `fromName()`/`tryFromName()` para todos.
+
+```php
+use ArchTech\Enums\From;
+
+enum Role
+{
+    use From;
+
+    case ADMIN;
+    case USER;
+}
+
+Role::from('ADMIN');          // Role::ADMIN
+Role::tryFrom('GHOST');       // null
+Role::fromName('ADMIN');      // Role::ADMIN (para backed enums)
+```
+
+### 6. Metadata - Metadados com Atributos
+
+Permite adicionar metadados aos cases usando atributos PHP 8.
+
+```php
+use ArchTech\Enums\Metadata;
+use ArchTech\Enums\Meta\Meta;
+
+#[Meta(Description::class, Color::class)]
+enum TaskStatus: int
+{
+    use Metadata;
+
+    #[Description('Tarefa Pendente')] #[Color('yellow')]
+    case PENDING = 0;
+
+    #[Description('Concluída')] #[Color('green')]
+    case COMPLETED = 1;
+}
+
+// Acessar metadados
+TaskStatus::PENDING->description();  // 'Tarefa Pendente'
+TaskStatus::PENDING->color();        // 'yellow'
+```
+
+**Criar MetaProperty personalizada:**
+
+```php
+use ArchTech\Enums\Meta\MetaProperty;
+
+#[Attribute]
+class Icon extends MetaProperty
+{
+    // Personalizar nome do método
+    public static function method(): string
+    {
+        return 'icon';
+    }
+
+    // Transformar valor
+    protected function transform(mixed $value): mixed
+    {
+        return "fa-{$value}";
+    }
+
+    // Valor padrão
+    public static function defaultValue(): mixed
+    {
+        return 'fa-circle';
+    }
+}
+```
+
+**PHPDoc para suporte de IDE:**
+
+```php
+/**
+ * @method string description()
+ * @method string color()
+ * @method string icon()
+ */
+#[Meta(Description::class, Color::class, Icon::class)]
+enum TaskStatus: int
+{
+    use Metadata;
+
+    #[Description('Pendente')] #[Color('yellow')] #[Icon('clock')]
+    case PENDING = 0;
+}
+```
+
+### 7. Comparable - Comparações
+
+Permite comparar enums com `is()`, `isNot()`, `in()` e `notIn()`.
+
+```php
+use ArchTech\Enums\Comparable;
+
+enum TaskStatus: int
+{
+    use Comparable;
+
+    case PENDING = 0;
+    case COMPLETED = 1;
+}
+
+TaskStatus::PENDING->is(TaskStatus::PENDING);           // true
+TaskStatus::PENDING->isNot(TaskStatus::COMPLETED);      // true
+TaskStatus::PENDING->in([TaskStatus::PENDING, TaskStatus::COMPLETED]);  // true
+TaskStatus::PENDING->notIn([TaskStatus::COMPLETED]);    // true
+```
+
+## Integração com Laravel
+
+### Cast em Modelos Eloquent
+
+```php
+use Illuminate\Database\Eloquent\Model;
+
+class Task extends Model
+{
+    protected $casts = [
+        'status' => TaskStatus::class,
+    ];
+}
+
+// Uso
+$task->status = TaskStatus::COMPLETED;
+$task->save();  // Salva como integer no banco
+
+// Recupera automaticamente como enum
+$task->status;  // TaskStatus::COMPLETED (instância)
+$task->status->value;  // 1
+```
+
+### Validação em Requests
+
+```php
+use Illuminate\Validation\Rule;
+
+// Usando valores do enum
+'status' => 'required|in:' . implode(',', TaskStatus::values())
+
+// Usando Enum rule (Laravel 10+)
+'status' => ['required', Rule::enum(TaskStatus::class)];
+```
+
+### Migration
+
+```php
+// Para backed enum int
+$table->tinyInteger('status');
+
+// Para backed enum string
+$table->string('status');
+```
+
+## Padrões de Uso Recomendados
+
+### Enum para Status com Metadata
+
+```php
+use ArchTech\Enums\{Metadata, Comparable, Options};
+use ArchTech\Enums\Meta\Meta;
+
+/**
+ * @method string description()
+ * @method string color()
+ * @method string icon()
+ */
+#[Meta(Description::class, Color::class, Icon::class)]
+enum TaskStatus: int
+{
+    use Metadata, Comparable, Options;
+
+    #[Description('Pendente')] #[Color('yellow')] #[Icon('clock')]
+    case PENDING = 0;
+
+    #[Description('Em Andamento')] #[Color('blue')] #[Icon('spinner')]
+    case IN_PROGRESS = 1;
+
+    #[Description('Concluída')] #[Color('green')] #[Icon('check')]
+    case COMPLETED = 2;
+
+    #[Description('Cancelada')] #[Color('red')] #[Icon('times')]
+    case CANCELED = 3;
+}
+```
+
+### Enum para Permissões
+
+```php
+use ArchTech\Enums\{Comparable, From};
+
+enum Permission: string
+{
+    use Comparable, From;
+
+    case USER_READ = 'user.read';
+    case USER_WRITE = 'user.write';
+    case USER_DELETE = 'user.delete';
+    case POST_READ = 'post.read';
+    case POST_WRITE = 'post.write';
+    case POST_DELETE = 'post.delete';
+
+    // Verificar se é permissão de usuário
+    public function isUserPermission(): bool
+    {
+        return str_starts_with($this->value, 'user.');
+    }
+
+    // Verificar se é permissão de post
+    public function isPostPermission(): bool
+    {
+        return str_starts_with($this->value, 'post.');
+    }
+}
+
+// Uso
+if ($user->permission->is(Permission::USER_READ)) {
+    // ...
+}
+
+if ($permission->isUserPermission()) {
+    // ...
+}
+```
+
+### Enum para Configuração
+
+```php
+use ArchTech\Enums\{InvokableCases, Values};
+
+enum PaymentGateway: string
+{
+    use InvokableCases, Values;
+
+    case STRIPE = 'stripe';
+    case PAYPAL = 'paypal';
+    case MERCADO_PAGO = 'mercadopago';
+}
+
+// Em arquivo de config
+return [
+    'gateways' => [
+        PaymentGateway::STRIPE() => [
+            'secret' => env('STRIPE_SECRET'),
+            'webhook' => env('STRIPE_WEBHOOK'),
+        ],
+        PaymentGateway::PAYPAL() => [
+            'secret' => env('PAYPAL_SECRET'),
+            'webhook' => env('PAYPAL_WEBHOOK'),
+        ],
+    ],
+];
+```
+
+## Diretório de Enums
+
+No Laravel, mantenha enums em `app/Enums`:
+
+```
+app/
+└── Enums/
+    ├── TaskStatus.php
+    ├── Permission.php
+    ├── PaymentGateway.php
+    └── MetaProperties/         # Atributos customizados
+        ├── Description.php
+        ├── Color.php
+        └── Icon.php
+```
+
+## Referências Adicionais
+
+- [Repositório GitHub](https://github.com/archtechx/enums)
+- [Packagist](https://packagist.org/packages/archtechx/enums)
+- [PHP 8.1 Enums](https://www.php.net/manual/pt_BR/language.types.enumerations.php)

--- a/skills/laravel-enums/references/advanced-patterns.md
+++ b/skills/laravel-enums/references/advanced-patterns.md
@@ -1,0 +1,504 @@
+# Padrões Avançados com archtechx/enums
+
+## Enum com Métodos Helper
+
+```php
+use ArchTech\Enums\{Metadata, Comparable, Options};
+use ArchTech\Enums\Meta\Meta;
+
+/**
+ * @method string label()
+ * @method string color()
+ * @method string icon()
+ * @method bool canTransitionTo()
+ */
+#[Meta(Label::class, Color::class, Icon::class)]
+enum OrderStatus: int
+{
+    use Metadata, Comparable, Options;
+
+    #[Label('Aguardando Pagamento')] #[Color('yellow')] #[Icon('clock')]
+    case PENDING = 0;
+
+    #[Label('Pago')] #[Color('blue')] #[Icon('credit-card')]
+    case PAID = 1;
+
+    #[Label('Processando')] #[Color('purple')] #[Icon('cog')]
+    case PROCESSING = 2;
+
+    #[Label('Enviado')] #[Color('indigo')] #[Icon('truck')]
+    case SHIPPED = 3;
+
+    #[Label('Entregue')] #[Color('green')] #[Icon('check-circle')]
+    case DELIVERED = 4;
+
+    #[Label('Cancelado')] #[Color('red')] #[Icon('times-circle')]
+    case CANCELED = 5;
+
+    #[Label('Reembolsado')] #[Color('gray')] #[Icon('undo')]
+    case REFUNDED = 6;
+
+    /**
+     * Verifica se o pedido pode transitar para outro status
+     */
+    public function canTransitionTo(self $status): bool
+    {
+        return match ($this) {
+            self::PENDING => in_array($status, [self::PAID, self::CANCELED]),
+            self::PAID => in_array($status, [self::PROCESSING, self::REFUNDED]),
+            self::PROCESSING => in_array($status, [self::SHIPPED]),
+            self::SHIPPED => in_array($status, [self::DELIVERED]),
+            self::DELIVERED => in_array($status, [self::REFUNDED]),
+            default => false,
+        };
+    }
+
+    /**
+     * Retorna os próximos status possíveis
+     */
+    public function nextStatuses(): array
+    {
+        return collect(self::cases())
+            ->filter(fn ($status) => $this->canTransitionTo($status))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Verifica se é um status final
+     */
+    public function isFinal(): bool
+    {
+        return in_array($this, [self::DELIVERED, self::CANCELED, self::REFUNDED]);
+    }
+
+    /**
+     * Retorna o progresso percentual
+     */
+    public function progress(): int
+    {
+        return match ($this) {
+            self::PENDING => 10,
+            self::PAID => 25,
+            self::PROCESSING => 40,
+            self::SHIPPED => 70,
+            self::DELIVERED => 100,
+            self::CANCELED, self::REFUNDED => 0,
+        };
+    }
+}
+```
+
+## Enum Backed com String
+
+```php
+use ArchTech\Enums\{From, Options, Comparable};
+
+enum SubscriptionPlan: string
+{
+    use From, Options, Comparable;
+
+    case FREE = 'free';
+    case BASIC = 'basic';
+    case PRO = 'pro';
+    case ENTERPRISE = 'enterprise';
+
+    /**
+     * Retorna o preço mensal em centavos
+     */
+    public function monthlyPrice(): int
+    {
+        return match ($this) {
+            self::FREE => 0,
+            self::BASIC => 990,      // R$ 9,90
+            self::PRO => 2990,       // R$ 29,90
+            self::ENTERPRISE => 9990, // R$ 99,90
+        };
+    }
+
+    /**
+     * Retorna o preço anual em centavos
+     */
+    public function yearlyPrice(): int
+    {
+        return (int) ($this->monthlyPrice() * 10); // 2 meses grátis
+    }
+
+    /**
+     * Recursos disponíveis
+     */
+    public function features(): array
+    {
+        return match ($this) {
+            self::FREE => [
+                '5 projetos',
+                '1 usuário',
+                'Suporte por email',
+            ],
+            self::BASIC => [
+                '20 projetos',
+                '3 usuários',
+                'Suporte prioritário',
+                'API básica',
+            ],
+            self::PRO => [
+                'Projetos ilimitados',
+                '10 usuários',
+                'Suporte dedicado',
+                'API completa',
+                'Webhooks',
+                'SSO',
+            ],
+            self::ENTERPRISE => [
+                'Tudo do PRO',
+                'Usuários ilimitados',
+                'SLA garantido',
+                'Gerente de conta',
+                'Customização',
+                'On-premise option',
+            ],
+        };
+    }
+
+    /**
+     * Verifica se tem um recurso específico
+     */
+    public function hasFeature(string $feature): bool
+    {
+        return str_contains(
+            implode(' ', $this->features()),
+            $feature
+        );
+    }
+
+    /**
+     * Limite de usuários
+     */
+    public function userLimit(): int
+    {
+        return match ($this) {
+            self::FREE => 1,
+            self::BASIC => 3,
+            self::PRO => 10,
+            self::ENTERPRISE => -1, // ilimitado
+        };
+    }
+
+    /**
+     * Se é ilimitado
+     */
+    public function isUnlimited(): bool
+    {
+        return $this->userLimit() === -1;
+    }
+}
+```
+
+## MetaProperties Avançadas
+
+```php
+<?php
+
+namespace App\Enums\MetaProperties;
+
+use ArchTech\Enums\Meta\MetaProperty;
+
+#[Attribute]
+class Label extends MetaProperty
+{
+    public static function method(): string
+    {
+        return 'label';
+    }
+
+    protected function transform(mixed $value): mixed
+    {
+        return $value;
+    }
+
+    public static function defaultValue(): mixed
+    {
+        return '';
+    }
+}
+
+#[Attribute]
+class Color extends MetaProperty
+{
+    public static function method(): string
+    {
+        return 'color';
+    }
+
+    protected function transform(mixed $value): mixed
+    {
+        // Transformar para classe Tailwind
+        return "bg-{$value}-500 text-white";
+    }
+
+    public static function defaultValue(): mixed
+    {
+        return 'bg-gray-500 text-white';
+    }
+}
+
+#[Attribute]
+class Icon extends MetaProperty
+{
+    public static function method(): string
+    {
+        return 'icon';
+    }
+
+    protected function transform(mixed $value): mixed
+    {
+        // Adicionar prefixo Font Awesome
+        return "fa-solid fa-{$value}";
+    }
+
+    public static function defaultValue(): mixed
+    {
+        return 'fa-solid fa-circle';
+    }
+}
+
+#[Attribute]
+class BadgeClass extends MetaProperty
+{
+    public static function method(): string
+    {
+        return 'badgeClass';
+    }
+
+    protected function transform(mixed $value): mixed
+    {
+        return "badge-{$value}";
+    }
+
+    public static function defaultValue(): mixed
+    {
+        return 'badge-neutral';
+    }
+}
+```
+
+## Testando Enums com Pest
+
+```php
+use App\Enums\OrderStatus;
+use PHPUnit\Framework\TestCase;
+
+test('order status transitions work correctly', function () {
+    expect(OrderStatus::PENDING->canTransitionTo(OrderStatus::PAID))
+        ->toBeTrue();
+
+    expect(OrderStatus::PENDING->canTransitionTo(OrderStatus::DELIVERED))
+        ->toBeFalse();
+
+    expect(OrderStatus::DELIVERED->isFinal())
+        ->toBeTrue();
+});
+
+test('order status returns correct progress', function () {
+    expect(OrderStatus::PENDING->progress())
+        ->toBe(10);
+
+    expect(OrderStatus::DELIVERED->progress())
+        ->toBe(100);
+});
+
+test('comparable trait works', function () {
+    $status = OrderStatus::PENDING;
+
+    expect($status->is(OrderStatus::PENDING))
+        ->toBeTrue();
+
+    expect($status->isNot(OrderStatus::PAID))
+        ->toBeTrue();
+
+    expect($status->in([OrderStatus::PENDING, OrderStatus::PAID]))
+        ->toBeTrue();
+});
+```
+
+## Factory com Enums
+
+```php
+use App\Enums\OrderStatus;
+use App\Models\Order;
+
+class OrderFactory extends Factory
+{
+    protected $model = Order::class;
+
+    public function definition(): array
+    {
+        return [
+            'status' => fake()->randomElement(OrderStatus::values()),
+            'total' => fake()->numberBetween(1000, 100000),
+        ];
+    }
+
+    public function pending(): self
+    {
+        return $this->state(fn () => [
+            'status' => OrderStatus::PENDING,
+        ]);
+    }
+
+    public function paid(): self
+    {
+        return $this->state(fn () => [
+            'status' => OrderStatus::PAID,
+        ]);
+    }
+
+    public function delivered(): self
+    {
+        return $this->state(fn () => [
+            'status' => OrderStatus::DELIVERED,
+        ]);
+    }
+}
+
+// Uso em测试
+Order::factory()->pending()->create();
+Order::factory()->paid()->count(5)->create();
+```
+
+## Blade Component para Enum Select
+
+```php
+// app/View/Components/EnumSelect.php
+
+namespace App\View\Components;
+
+use Illuminate\View\Component;
+use UnitEnum;
+
+class EnumSelect extends Component
+{
+    public function __construct(
+        public UnitEnum $enum,
+        public string $name,
+        public ?string $value = null,
+        public string $id = null,
+    ) {
+        $this->id = $id ?? $name;
+    }
+
+    public function options(): array
+    {
+        if (method_exists($this->enum, 'options')) {
+            return $this->enum::options();
+        }
+
+        return [];
+    }
+
+    public function render()
+    {
+        return view('components.enum-select');
+    }
+}
+```
+
+```blade
+{{-- resources/views/components/enum-select.blade.php --}}
+<select {{ $attributes->merge(['class' => 'select select-bordered', 'id' => $id, 'name' => $name]) }}>
+    @foreach($options() as $name => $value)
+        <option value="{{ $value }}" {{ $value == $old($name, $value) ? 'selected' : '' }}>
+            {{ Str::headline($name) }}
+        </option>
+    @endforeach
+</select>
+```
+
+```blade
+{{-- Uso --}}
+<x-enum-select :enum="OrderStatus::class" name="status" :value="$order->status" />
+```
+
+## Observer para Enums
+
+```php
+use App\Enums\OrderStatus;
+use App\Models\Order;
+
+class OrderObserver
+{
+    public function creating(Order $order): void
+    {
+        if ($order->status === null) {
+            $order->status = OrderStatus::PENDING;
+        }
+    }
+
+    public function updating(Order $order): void
+    {
+        if ($order->isDirty('status')) {
+            $oldStatus = $order->getOriginal('status');
+            $newStatus = $order->status;
+
+            // Validar transição
+            if (!$oldStatus->canTransitionTo($newStatus)) {
+                throw new \InvalidArgumentException(
+                    "Cannot transition from {$oldStatus->label()} to {$newStatus->label()}"
+                );
+            }
+
+            // Log da transição
+            OrderStatusTransition::create([
+                'order_id' => $order->id,
+                'from' => $oldStatus,
+                'to' => $newStatus,
+            ]);
+        }
+    }
+}
+```
+
+## Query Scope com Enums
+
+```php
+use App\Enums\OrderStatus;
+use Illuminate\Database\Eloquent\Builder;
+
+class Order extends Model
+{
+    // ...
+
+    public function scopeWithStatus(Builder $query, OrderStatus $status): Builder
+    {
+        return $query->where('status', $status->value);
+    }
+
+    public function scopeWithStatuses(Builder $query, array $statuses): Builder
+    {
+        return $query->whereIn('status', array_map(fn ($s) => $s->value, $statuses));
+    }
+
+    public function scopePending(Builder $query): Builder
+    {
+        return $this->withStatus(OrderStatus::PENDING);
+    }
+
+    public function scopeDelivered(Builder $query): Builder
+    {
+        return $this->withStatus(OrderStatus::DELIVERED);
+    }
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $this->withStatuses([
+            OrderStatus::PAID,
+            OrderStatus::PROCESSING,
+            OrderStatus::SHIPPED,
+        ]);
+    }
+}
+
+// Uso
+Order::pending()->get();
+Order::active()->with('customer')->get();
+```

--- a/skills/laravel-enums/scripts/make-enum.php
+++ b/skills/laravel-enums/scripts/make-enum.php
@@ -1,0 +1,109 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Script para criar um novo enum com archtechx/enums
+ *
+ * Uso: php scripts/make-enum.php PaymentStatus int
+ *      php scripts/make-enum.php Role string
+ */
+
+if ($argc < 3) {
+    echo "Uso: php make-enum.php <NomeDoEnum> <backingType> [pure]\n";
+    echo "Exemplo: php make-enum.php PaymentStatus int\n";
+    echo "         php make-enum.php Role string\n";
+    echo "         php make-enum.php Color pure\n";
+    exit(1);
+}
+
+$enumName = $argv[1];
+$backingType = strtolower($argv[2]);
+$usePure = isset($argv[3]) && strtolower($argv[3]) === 'pure';
+
+// Validar backing type
+if (!in_array($backingType, ['int', 'string', 'pure'])) {
+    echo "Erro: backingType deve ser 'int', 'string' ou 'pure'\n";
+    exit(1);
+}
+
+$namespace = 'App\\Enums';
+$directory = 'app/Enums';
+
+// Criar diretório se não existir
+if (!is_dir($directory)) {
+    mkdir($directory, 0755, true);
+}
+
+$fileName = "{$directory}/{$enumName}.php";
+
+// Verificar se arquivo já existe
+if (file_exists($fileName)) {
+    echo "Erro: {$enumName} já existe em {$fileName}\n";
+    exit(1);
+}
+
+// Gerar conteúdo do enum
+$content = generateEnumContent($enumName, $backingType, $usePure);
+
+// Escrever arquivo
+file_put_contents($fileName, $content);
+
+echo "✅ Enum {$enumName} criado em {$fileName}\n";
+echo "⚠️  Não esqueça de:\n";
+echo "   1. Adicionar os cases do enum\n";
+echo "   2. Criar migration se necessário\n";
+echo "   3. Adicionar cast no modelo se necessário\n";
+
+function generateEnumContent(string $name, string $backingType, bool $usePure): string
+{
+    $traits = [
+        'use ArchTech\\Enums\\Options;',
+        'use ArchTech\\Enums\\Comparable;',
+        'use ArchTech\\Enums\\From;',
+    ];
+
+    $usePure = $backingType === 'pure';
+    $backingDeclaration = $usePure ? '' : ": " . ($backingType === 'string' ? 'string' : 'int');
+
+    $phpdoc = generatePhpDoc();
+
+    $traitsImploded = implode("\n    ", $traits);
+    $uses = implode("\n", array_filter([
+        "use ArchTech\\Enums\\Options;",
+        "use ArchTech\\Enums\\Comparable;",
+        $usePure ? "use ArchTech\\Enums\\From;" : "",
+    ]));
+
+    return <<<PHP
+<?php
+
+namespace App\\Enums;
+
+{$uses}
+
+{$phpdoc}
+enum {$name}{$backingDeclaration}
+{
+    use Options, Comparable;
+
+    // Adicione seus cases aqui
+    // Exemplo:
+    // case EXAMPLE = 1;
+}
+PHP;
+}
+
+function generatePhpDoc(): string
+{
+    return <<<DOC
+/**
+ * Enum {$name}
+ *
+ * @method static array options()
+ * @method bool is(self \$other)
+ * @method bool isNot(self \$other)
+ * @method bool in(array \$others)
+ * @method bool notIn(array \$others)
+ */
+DOC;
+}


### PR DESCRIPTION
Skill para trabalhar com enums PHP 8.1+ usando o pacote archtechx/enums. Inclui documentação dos 7 traits (InvokableCases, Names, Values, Options, From, Metadata, Comparable), integração com Laravel (cast, validação, migration) e script gerador de enums.